### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests==2.27.1
 sqlparse==0.4.2
 urllib3==1.26.9
 yarg==0.1.9
-channels=3.0.5
+channels==3.0.5
 django-crispy-forms
 Pillow
 crispy-bootstrap4


### PR DESCRIPTION
Missing equal sign in channels==3.0.5 from requirements.txt. Syntax error prevents installation